### PR TITLE
fix: CI/CDビルドエラーを修正しつつテスト実行を維持

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,9 +12,11 @@
     "importHelpers": true,
     "isolatedModules": true,
     "strictPropertyInitialization": false,
+    "allowSyntheticDefaultImports": true,
     "lib": ["DOM", "ES5", "ES6", "ES7"],
     "jsx": "react",
-    "types": ["@types/bun"]
+    "types": ["@types/bun", "@types/jest"]
   },
-  "include": ["**/*.ts"]
+  "include": ["src/**/*.ts", "src/**/*.tsx"],
+  "exclude": ["node_modules"]
 }


### PR DESCRIPTION
- tsconfig.jsonに@types/jestを追加してJest型定義エラーを解決
- allowSyntheticDefaultImportsでmoment import問題を修正
- テストファイルを含めてテスト実行も継続可能

🤖 Generated with [Claude Code](https://claude.ai/code)