### PR TITLE
Remove QuickPostModal header and reduce padding

### DIFF
--- a/src/ui/QuickPostModal.ts
+++ b/src/ui/QuickPostModal.ts
@@ -25,8 +25,8 @@ export class QuickPostModal extends Modal {
   onOpen() {
     const { contentEl, titleEl } = this;
     // Hide modal title per request
-    titleEl.empty();
-    (titleEl as HTMLElement).style.display = "none";
+    titleEl.remove();
+    contentEl.style.paddingTop = "0.5rem";
 
     const wrapper = contentEl.createDiv({ cls: "mobile-memo-quick-post" });
     // Match main view spacing: vertical stack with 0.75rem gap


### PR DESCRIPTION
## Summary
- drop QuickPostModal title element on open
- tighten top spacing by setting modal content padding

## Testing
- `npm test` *(fails: Cannot find module 'src/utils/collections'; fetch failed errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b3aac13af483289ba9fa2e8be882a1