### PR TITLE
Fix input footer alignment on mobile keyboard

### DIFF
--- a/src/ui/ReactView.tsx
+++ b/src/ui/ReactView.tsx
@@ -221,7 +221,7 @@ export const ReactView = ({
 
   useEffect(() => {
     let timeoutId: number;
-    
+
     const updateViewport = () => {
       // iOS でのタイミング問題を解決するためにデバウンス処理を追加
       clearTimeout(timeoutId);
@@ -237,24 +237,24 @@ export const ReactView = ({
         });
       }, 10);
     };
-    
+
     updateViewport();
-    
+
     // より包括的なイベント監視
-    const events = ['resize', 'scroll'];
-    events.forEach(event => {
+    const events = ["resize", "scroll"];
+    events.forEach((event) => {
       window.visualViewport?.addEventListener(event, updateViewport);
     });
-    
+
     // iOS 特有のオリエンテーション変化も監視
-    window.addEventListener('orientationchange', updateViewport);
-    
+    window.addEventListener("orientationchange", updateViewport);
+
     return () => {
       clearTimeout(timeoutId);
-      events.forEach(event => {
+      events.forEach((event) => {
         window.visualViewport?.removeEventListener(event, updateViewport);
       });
-      window.removeEventListener('orientationchange', updateViewport);
+      window.removeEventListener("orientationchange", updateViewport);
     };
   }, []);
 
@@ -535,7 +535,7 @@ export const ReactView = ({
           overscrollBehavior: "contain",
           WebkitOverflowScrolling: "touch",
         }}
-        paddingBottom={footerHeight}
+        paddingBottom={footerHeight + (viewport.occluded ?? 0)}
       >
         {currentDailyNote && contents}
       </Box>
@@ -545,34 +545,26 @@ export const ReactView = ({
         position="sticky"
         bottom={0}
         transform={
-          Platform.isMobile && (isInputFocused || (viewport.occluded ?? 0) > 50)
-            ? (() => {
-                // キーボードの高さよりさらに20px上に配置して完全に密着
-                const translateY = -(viewport.occluded + 20);
-                console.log('[KEYBOARD DEBUG]', {
-                  occluded: viewport.occluded,
-                  translateY,
-                  windowHeight: window.innerHeight,
-                  visualViewportHeight: window.visualViewport?.height,
-                  isInputFocused
-                });
-                return `translateY(${translateY}px)`;
-              })()
-            : 'none'
+          Platform.isMobile && (viewport.occluded ?? 0) > 0
+            ? `translateY(${-viewport.occluded}px)`
+            : "none"
         }
         zIndex={1}
         bg="var(--background-primary)"
         p={isInputFocused && Platform.isMobile ? 0 : 2}
         // iOS でのスペーシング完全除去
-        sx={isInputFocused && Platform.isMobile ? {
-          margin: 0,
-          border: 'none',
-          outline: 'none',
-          boxSizing: 'border-box'
-        } : {}}
+        sx={
+          isInputFocused && Platform.isMobile
+            ? {
+                margin: 0,
+                border: "none",
+                outline: "none",
+                boxSizing: "border-box",
+              }
+            : {}
+        }
         pb={
-          Platform.isMobile &&
-          (isInputFocused || (viewport.occluded ?? 0) > 50) // 閾値を100から50に下げて、より敏感に反応
+          Platform.isMobile && (viewport.occluded ?? 0) > 0
             ? 0
             : "env(safe-area-inset-bottom, 0px)"
         }
@@ -593,24 +585,32 @@ export const ReactView = ({
           width="100%"
           marginBottom={isInputFocused && Platform.isMobile ? 0 : 2}
           // iOS でのスペース除去のための強制スタイル
-          sx={isInputFocused && Platform.isMobile ? {
-            border: 'none',
-            boxShadow: 'none',
-            _focus: {
-              border: 'none',
-              boxShadow: 'none'
-            }
-          } : {}}
+          sx={
+            isInputFocused && Platform.isMobile
+              ? {
+                  border: "none",
+                  boxShadow: "none",
+                  _focus: {
+                    border: "none",
+                    boxShadow: "none",
+                  },
+                }
+              : {}
+          }
         />
-        <HStack 
-          width="100%" 
-          minHeight="3.5em" 
+        <HStack
+          width="100%"
+          minHeight="3.5em"
           alignItems="center"
           spacing={isInputFocused && Platform.isMobile ? 1 : 2}
-          sx={isInputFocused && Platform.isMobile ? {
-            margin: 0,
-            padding: 0
-          } : {}}
+          sx={
+            isInputFocused && Platform.isMobile
+              ? {
+                  margin: 0,
+                  padding: 0,
+                }
+              : {}
+          }
         >
           <Button
             isDisabled={!canSubmit}


### PR DESCRIPTION
## Summary
- account for visual viewport occlusion in scroll padding
- translate footer exactly by occluded height to stay attached to keyboard

## Testing
- `npx tsc --noEmit --skipLibCheck` *(fails: Property 'replaceAll' does not exist)*
- `bun run test` *(fails: fetch failed / ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_68bd7cca06bc8328bdb4197c19ccd8f9